### PR TITLE
Create index for samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>HTML Samples Dashboard</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/materia/bootstrap.min.css"
+  />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css"
+  />
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 40px;
+      background: #f4f4f4;
+    }
+
+    .container {
+      max-width: 600px;
+      margin: auto;
+      background: #fff;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    }
+
+    h1 {
+      text-align: center;
+      margin-top: 0;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+
+    li {
+      margin: 10px 0;
+    }
+
+    a {
+      text-decoration: none;
+      color: #333;
+      font-size: 18px;
+    }
+
+    a:hover {
+      color: #007bff;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>HTML Samples</h1>
+    <ul>
+      <li><a href="inbound.html">Inbound: 24-Hour Door Schedule</a></li>
+      <li><a href="upload_progress_and_dark_mode.html">Progressive Image Upload Demo</a></li>
+    </ul>
+  </div>
+  <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple index.html dashboard linking to existing HTML samples
- include Bootswatch Materia theme before custom CSS and retain Material Components Web resources

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6883c53c2c848320af1b15fb31689f85