### PR TITLE
Create index for samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>HTML Samples Dashboard</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/materia/bootstrap.min.css"
+  />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css"
+  />
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 40px;
+      background: #f4f4f4;
+    }
+
+    .card-img-top {
+      height: 200px;
+      object-fit: cover;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1 class="text-center mb-4">HTML Samples</h1>
+    <div class="row">
+      <div class="col-md-4">
+        <div class="card mb-4">
+          <img
+            src="https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=400&h=200&q=60"
+            class="card-img-top"
+            alt="Warehouse" />
+          <div class="card-body text-center">
+            <h5 class="card-title">Inbound: 24-Hour Door Schedule</h5>
+            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#inboundModal">View Demo</a>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card mb-4">
+          <img
+            src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=400&h=200&q=60"
+            class="card-img-top"
+            alt="Laptop" />
+          <div class="card-body text-center">
+            <h5 class="card-title">Progressive Image Upload Demo</h5>
+            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#uploadModal">View Demo</a>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card mb-4">
+          <img
+            src="https://images.unsplash.com/photo-1559027615-7bccebc5f1ff?auto=format&fit=crop&w=400&h=200&q=60"
+            class="card-img-top"
+            alt="Mobile menu" />
+          <div class="card-body text-center">
+            <h5 class="card-title">Material Push Menu</h5>
+            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#menuModal">View Demo</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modals -->
+  <div class="modal fade" id="inboundModal" tabindex="-1" aria-labelledby="inboundLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="inboundLabel">Inbound: 24-Hour Door Schedule</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body p-0">
+          <iframe src="inbound.html" title="Inbound 24-Hour Door Schedule" style="width: 100%; height: 80vh; border: 0;"></iframe>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="uploadModal" tabindex="-1" aria-labelledby="uploadLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="uploadLabel">Progressive Image Upload Demo</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body p-0">
+          <iframe src="upload_progress_and_dark_mode.html" title="Progressive Image Upload Demo" style="width: 100%; height: 80vh; border: 0;"></iframe>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="menuModal" tabindex="-1" aria-labelledby="menuLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="menuLabel">Material Push Menu</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body p-0">
+          <iframe src="material_push_menu.html" title="Material Push Menu" style="width: 100%; height: 80vh; border: 0;"></iframe>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- present HTML samples as Bootstrap cards with Unsplash images
- link to material_push_menu.html alongside existing demos
- launch each sample in a Bootstrap modal with an embedded iframe

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6883c53c2c848320af1b15fb31689f85