### PR TITLE
Add progressive image capture demo and link

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,22 @@
           </div>
         </div>
       </div>
+      <div class="col-md-4">
+        <div class="card mb-4">
+          <img
+            src="https://images.unsplash.com/photo-1519183071298-a2962f7bdc93?auto=format&fit=crop&w=400&h=200&q=60"
+            class="card-img-top"
+            alt="Camera" />
+          <div class="card-body text-center">
+            <h5 class="card-title">Progressive Image Capture</h5>
+
+            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#captureModal">View Demo</a>
+
+            <a href="progressive_image_capture.html" class="btn btn-primary">View Demo</a>
+
+          </div>
+        </div>
+      </div>
     </div>
 
   </div>
@@ -166,6 +182,20 @@
     </div>
   </div>
 
+  <div class="modal fade" id="captureModal" tabindex="-1" aria-labelledby="captureLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="captureLabel">Progressive Image Capture</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body p-0">
+          <iframe src="progressive_image_capture.html" title="Progressive Image Capture" style="width: 100%; height: 80vh; border: 0;"></iframe>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
 
@@ -173,6 +203,8 @@
     <ul>
       <li><a href="inbound.html">Inbound: 24-Hour Door Schedule</a></li>
       <li><a href="upload_progress_and_dark_mode.html">Progressive Image Upload Demo</a></li>
+      <li><a href="material_push_menu.html">Material Push Menu</a></li>
+      <li><a href="progressive_image_capture.html">Progressive Image Capture</a></li>
     </ul>
 
   </div>

--- a/progressive_image_capture.html
+++ b/progressive_image_capture.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Progressive Image Capture</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/materia/bootstrap.min.css"
+  />
+  <style>
+    body {
+      margin: 40px;
+      font-family: Arial, sans-serif;
+    }
+
+    #preview img {
+      max-width: 100%;
+      margin-top: 20px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1 class="mb-4 text-center">Progressive Image Capture</h1>
+    <input
+      type="file"
+      accept="image/*"
+      capture="environment"
+      class="form-control mb-3"
+      id="fileInput"
+    />
+    <div class="progress mb-3" id="progressContainer" style="display: none;">
+      <div class="progress-bar" role="progressbar" style="width: 0%;" id="progressBar"></div>
+    </div>
+    <div id="preview" class="text-center"></div>
+  </div>
+
+  <script>
+    const input = document.getElementById('fileInput');
+    const progressContainer = document.getElementById('progressContainer');
+    const progressBar = document.getElementById('progressBar');
+    const preview = document.getElementById('preview');
+
+    input.addEventListener('change', (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      progressContainer.style.display = 'block';
+      progressBar.style.width = '0%';
+      reader.onprogress = (ev) => {
+        if (ev.lengthComputable) {
+          const percent = (ev.loaded / ev.total) * 100;
+          progressBar.style.width = percent + '%';
+        }
+      };
+      reader.onload = (ev) => {
+        progressBar.style.width = '100%';
+        const img = document.createElement('img');
+        img.src = ev.target.result;
+        img.alt = 'Captured image';
+        preview.innerHTML = '';
+        preview.appendChild(img);
+      };
+      reader.readAsDataURL(file);
+    });
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add progressive image capture page with progress bar and preview
- link new page from dashboard via card, modal, and list

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689e29a0753c83209f23bb2805f62303